### PR TITLE
chore: update vite to ^6.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "prettier": "^3.5.3",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.1",
-        "vite": "^6.2.1"
+        "vite": "^6.2.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4681,7 +4681,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.1",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.2.1"
+    "vite": "^6.2.3"
   },
   "dependencies": {
     "react": "^19.0.0",


### PR DESCRIPTION
# Description

Update Vite dependency from ^6.2.1 to ^6.2.3 to get the latest bug fixes and improvements.

## Test
Manually tested - verified that the development server starts and runs correctly.